### PR TITLE
Relax deps to allow poison 2.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ExTwitter.Mixfile do
   def deps do
     [
       {:oauth, github: "tim/erlang-oauth"},
-      {:poison, "~> 1.5"},
+      {:poison, "~> 1.5 or ~> 2.1"},
       {:exvcr, "~> 0.6", only: :test},
       {:excoveralls, "~> 0.4", only: :test},
       {:meck, "~> 0.8.2", only: [:dev, :test]},


### PR DESCRIPTION
Hello Parroty, I made this pull request to relax the deps of poison to allow version 2.1 since a lot of Elixir apps are now using that version. Thanks!
